### PR TITLE
feat: add dataset upload controller flow

### DIFF
--- a/Controllers/UploadsController.cs
+++ b/Controllers/UploadsController.cs
@@ -1,4 +1,4 @@
-﻿using BIDashboardBackend.DTOs.Request;
+using BIDashboardBackend.DTOs.Request;
 using BIDashboardBackend.Interfaces;
 using Microsoft.AspNetCore.Mvc;
 
@@ -11,7 +11,6 @@ namespace BIDashboardBackend.Controllers
         private readonly IIngestService _svc;
         public UploadsController(IIngestService svc) => _svc = svc;
 
-
         [HttpPost("csv")]
         [DisableRequestSizeLimit]
         public async Task<IActionResult> UploadCsv([FromForm] IFormFile file)
@@ -20,12 +19,19 @@ namespace BIDashboardBackend.Controllers
             return Ok(result);
         }
 
-
         [HttpPut("mappings")]
         public async Task<IActionResult> UpsertMappings([FromBody] UpsertMappingsRequestDto body)
         {
             await _svc.UpsertMappingsAsync(body);
             return NoContent();
         }
+
+        [HttpGet("{batchId}/columns")]
+        public async Task<IActionResult> GetColumns(long batchId)
+        {
+            var cols = await _svc.GetColumnsAsync(batchId);
+            return Ok(cols);
+        }
     }
 }
+

--- a/DTOs/Request/MappingDtos.cs
+++ b/DTOs/Request/MappingDtos.cs
@@ -1,4 +1,6 @@
-﻿namespace BIDashboardBackend.DTOs.Request
+using BIDashboardBackend.Enums;
+
+namespace BIDashboardBackend.DTOs.Request
 {
     public sealed class UpsertMappingsRequestDto
     {
@@ -6,10 +8,10 @@
         public List<SourceToSystemField> Mappings { get; init; } = new();
     }
 
-
     public sealed class SourceToSystemField
     {
         public string SourceColumn { get; init; } = string.Empty; // CSV 欄位名稱
         public SystemField SystemField { get; init; }
     }
 }
+

--- a/Interfaces/IIngestService.cs
+++ b/Interfaces/IIngestService.cs
@@ -1,5 +1,6 @@
 ﻿using BIDashboardBackend.DTOs.Request;
 using BIDashboardBackend.DTOs.Response;
+using BIDashboardBackend.Models;
 
 namespace BIDashboardBackend.Interfaces
 {
@@ -7,5 +8,6 @@ namespace BIDashboardBackend.Interfaces
     {
         Task<UploadResultDto> UploadCsvAsync(IFormFile file);
         Task UpsertMappingsAsync(UpsertMappingsRequestDto request);
+        Task<IReadOnlyList<DatasetColumn>> GetColumnsAsync(long batchId);
     }
 }

--- a/Interfaces/Repositories/IDatasetRepository.cs
+++ b/Interfaces/Repositories/IDatasetRepository.cs
@@ -1,14 +1,14 @@
 ﻿using BIDashboardBackend.Models;
-using System.Data;
 
 namespace BIDashboardBackend.Interfaces.Repositories
 {
     public interface IDatasetRepository
     {
-        Task<long> CreateBatchAsync(string fileName, long totalRows, IDbTransaction tx);
-        Task<int> SetBatchStatusAsync(long batchId, string status, string? errorMessage, IDbTransaction tx);
-        Task<int> UpsertColumnsAsync(long batchId, IEnumerable<DatasetColumn> columns, IDbTransaction tx);
-        Task<int> UpsertMappingsAsync(long batchId, IEnumerable<DatasetMapping> mappings, IDbTransaction tx);
+        Task<long> CreateBatchAsync(string fileName, long totalRows);
+        Task<int> SetBatchStatusAsync(long batchId, string status, string? errorMessage);
+        Task<int> UpsertColumnsAsync(long batchId, IEnumerable<DatasetColumn> columns);
+        Task<int> UpsertMappingsAsync(long batchId, IEnumerable<DatasetMapping> mappings);
+        Task<IReadOnlyList<DatasetColumn>> GetColumnsAsync(long batchId);
 
 
         // 匯入資料：MVP 可先以 batched insert；正式可用 COPY

--- a/Services/IngestService.cs
+++ b/Services/IngestService.cs
@@ -4,6 +4,7 @@ using BIDashboardBackend.Features.Ingest;
 using BIDashboardBackend.Features.Jobs;
 using BIDashboardBackend.Interfaces;
 using BIDashboardBackend.Interfaces.Repositories;
+using BIDashboardBackend.Models;
 using Hangfire;
 
 namespace BIDashboardBackend.Services
@@ -31,34 +32,44 @@ namespace BIDashboardBackend.Services
 
 
             await _uow.BeginAsync();
-            using var stream = file.OpenReadStream();
+            await using var stream = file.OpenReadStream();
             var (totalRows, columns) = await _sniffer.ProbeAsync(stream, batchId: 0);
 
-
+            stream.Position = 0;
             var batchId = await _repo.CreateBatchAsync(file.FileName, totalRows);
             foreach (var col in columns) col.GetType().GetProperty("BatchId")?.SetValue(col, batchId);
             await _repo.UpsertColumnsAsync(batchId, columns);
-            await _uow.CommitAsync();
 
+            stream.Position = 0;
+            await _repo.BulkCopyRowsAsync(batchId, stream, CancellationToken.None);
+            await _uow.CommitAsync();
 
             // 匯入資料（COPY/batch insert）可在背景或此處進行；此處示意背景做 ETL
             _jobs.Enqueue<IEtlJob>(job => job.RunEtlForBatchAsync(batchId, CancellationToken.None));
 
-
-            return new UploadResultDto { BatchId = batchId, FileName = file.FileName, TotalRows = totalRows, Status = "Pending" };
+            return new UploadResultDto
+            {
+                BatchId = batchId,
+                FileName = file.FileName,
+                TotalRows = totalRows,
+                Status = "Pending"
+            };
         }
 
 
         public async Task UpsertMappingsAsync(UpsertMappingsRequestDto request)
         {
             await _uow.BeginAsync();
-            await _repo.UpsertMappingsAsync(request.BatchId, request.Mappings.ConvertAll(m => new Models.DatasetMapping
+            await _repo.UpsertMappingsAsync(request.BatchId, request.Mappings.ConvertAll(m => new DatasetMapping
             {
                 BatchId = request.BatchId,
                 SourceColumn = m.SourceColumn,
                 SystemField = m.SystemField
-            }), );
+            }));
             await _uow.CommitAsync();
         }
+
+        public Task<IReadOnlyList<DatasetColumn>> GetColumnsAsync(long batchId)
+            => _repo.GetColumnsAsync(batchId);
     }
 }


### PR DESCRIPTION
## Summary
- add endpoint to fetch detected columns for a batch
- persist raw CSV rows during upload and expose column retrieval in ingestion service
- update dataset repository and service interfaces to support new flow

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b49e293d648326b8771a365c2b8c30