### PR TITLE
Use Redis for refresh token storage

### DIFF
--- a/appsettings.json
+++ b/appsettings.json
@@ -5,5 +5,9 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Redis": {
+    "ConnectionString": "localhost:6379",
+    "KeyPrefix": "bi"
+  }
 }


### PR DESCRIPTION
## Summary
- Persist refresh tokens in Redis and attach expiry information, replacing in-memory dictionary
- Wire up Redis connection and cache service through dependency injection
- Provide Redis configuration in appsettings

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository access 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b4a61831448326b00c2934cca9cbba