### PR TITLE
feat: add endpoint to list user dataset IDs

### DIFF
--- a/Controllers/MeController.cs
+++ b/Controllers/MeController.cs
@@ -1,0 +1,33 @@
+using BIDashboardBackend.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace BIDashboardBackend.Controllers
+{
+    /// <summary>
+    /// 提供與目前用戶相關的查詢接口
+    /// </summary>
+    [ApiController]
+    [Route("api/me")]
+    [Authorize]
+    public sealed class MeController : BaseController
+    {
+        private readonly IDatasetService _datasetService;
+
+        /// <summary>
+        /// 建構子，注入資料集服務以查詢用戶可用的資料集
+        /// </summary>
+        public MeController(IDatasetService datasetService) => _datasetService = datasetService;
+
+        /// <summary>
+        /// 取得目前用戶可使用的所有資料集 ID
+        /// </summary>
+        /// <returns>資料集 ID 列表</returns>
+        [HttpGet("datasets")]
+        public async Task<IActionResult> GetDatasetIds()
+        {
+            var ids = await _datasetService.GetDatasetIdsAsync(UserId);
+            return Ok(ids);
+        }
+    }
+}

--- a/Interfaces/IDatasetService.cs
+++ b/Interfaces/IDatasetService.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace BIDashboardBackend.Interfaces
+{
+    /// <summary>
+    /// 資料集相關服務介面，提供資料集查詢功能
+    /// </summary>
+    public interface IDatasetService
+    {
+        /// <summary>
+        /// 取得指定用戶可使用的所有資料集 ID
+        /// </summary>
+        /// <param name="userId">用戶 ID</param>
+        /// <returns>該用戶可使用的資料集 ID 列表</returns>
+        Task<IReadOnlyList<long>> GetDatasetIdsAsync(long userId);
+    }
+}

--- a/Interfaces/Repositories/IDatasetRepository.cs
+++ b/Interfaces/Repositories/IDatasetRepository.cs
@@ -44,5 +44,12 @@ namespace BIDashboardBackend.Interfaces.Repositories
         /// <param name="userId">用戶 ID（用於權限驗證）</param>
         /// <returns>批次詳細資訊</returns>
         Task<UploadHistoryDto?> GetBatchDetailsAsync(long batchId, long userId);
+
+        /// <summary>
+        /// 取得用戶可使用的所有資料集 ID
+        /// </summary>
+        /// <param name="userId">用戶 ID</param>
+        /// <returns>資料集 ID 列表</returns>
+        Task<IReadOnlyList<long>> GetDatasetIdsByUserAsync(long userId);
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -64,6 +64,7 @@ builder.Services.AddSingleton<CacheKeyBuilder>();   // 產 Key 的工具
 builder.Services.AddScoped<IAuthService, AuthService>();
 builder.Services.AddScoped<IIngestService, IngestService>();
 builder.Services.AddScoped<IMetricService, MetricService>();
+builder.Services.AddScoped<IDatasetService, DatasetService>();
 builder.Services.AddScoped<IEtlJob,EtlJob>();
 
 // repo

--- a/Repositories/DatasetRepository.cs
+++ b/Repositories/DatasetRepository.cs
@@ -362,6 +362,22 @@ FROM UNNEST(@jsons::text[]) AS t(js);";
             return batch;
         }
 
+        /// <summary>
+        /// 取得指定用戶可使用的所有資料集 ID
+        /// </summary>
+        /// <param name="userId">用戶 ID</param>
+        /// <returns>資料集 ID 列表</returns>
+        public Task<IReadOnlyList<long>> GetDatasetIdsByUserAsync(long userId)
+        {
+            const string sql = @"
+                SELECT id
+                FROM datasets
+                WHERE owner_id = @userId
+                ORDER BY id;";
+
+            return _sql.QueryAsync<long>(sql, new { userId });
+        }
+
         private async Task<IReadOnlyList<UploadHistoryColumnDto>> GetBatchColumnsWithMappingAsync(long batchId)
         {
             const string sql = @"

--- a/Services/DatasetService.cs
+++ b/Services/DatasetService.cs
@@ -1,0 +1,26 @@
+using BIDashboardBackend.Interfaces;
+using BIDashboardBackend.Interfaces.Repositories;
+
+namespace BIDashboardBackend.Services
+{
+    /// <summary>
+    /// 資料集服務，封裝資料集的存取邏輯
+    /// </summary>
+    public sealed class DatasetService : IDatasetService
+    {
+        private readonly IDatasetRepository _repo;
+
+        /// <summary>
+        /// 建構子，注入資料集資料存取層
+        /// </summary>
+        public DatasetService(IDatasetRepository repo) => _repo = repo;
+
+        /// <summary>
+        /// 取得指定用戶可使用的所有資料集 ID
+        /// </summary>
+        /// <param name="userId">用戶 ID</param>
+        /// <returns>該用戶可使用的資料集 ID 列表</returns>
+        public Task<IReadOnlyList<long>> GetDatasetIdsAsync(long userId)
+            => _repo.GetDatasetIdsByUserAsync(userId);
+    }
+}


### PR DESCRIPTION
## Summary
- add dataset service and repository method to fetch user dataset ids
- expose /api/me/datasets endpoint returning current user's dataset ids
- wire dataset service into dependency injection

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bc71eb6bd483268c6f71f4af7348c0